### PR TITLE
Make Portfolio display all aspect ratios, improve image loading

### DIFF
--- a/about.html
+++ b/about.html
@@ -43,7 +43,7 @@
             </div>
         </section>
         <footer class="no-shrink">
-            <p><span class="copyright">©</span> Kyle Donahue 2018. All rights reserved.</p>
+            <p><span class="copyright">©</span> Kyle Donahue 2019. All rights reserved.</p>
         </footer>
     </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -60,7 +60,7 @@
             </div>
         </section>
         <footer class="no-shrink">
-            <p><span class="copyright">©</span> Kyle Donahue 2018. All rights reserved.</p>
+            <p><span class="copyright">©</span> Kyle Donahue 2019. All rights reserved.</p>
         </footer>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
             </div>
         </section>
         <footer class="no-shrink">
-            <p><span class="copyright">©</span> Kyle Donahue 2018. All rights reserved.</p>
+            <p><span class="copyright">©</span> Kyle Donahue 2019. All rights reserved.</p>
         </footer>
     </body>
 </html>

--- a/js/javascript.js
+++ b/js/javascript.js
@@ -129,13 +129,13 @@ $(document).on('ready', function(){
         $('div#gallery').loadFlickrPhotos({ 
             photoset_id: '72157704053325964',
             per_page: 9,
-            classes: 'rectangles'
+            classes: 'uniform'
         });
     } else if(window.location.pathname.includes('portfolio')){
         // load portfolio photos album
         $('div#gallery').loadFlickrPhotos({ 
             photoset_id: '72157708286336705',
-            classes: 'squares'
+            classes: 'ragged'
         });
     }
 });

--- a/js/javascript.js
+++ b/js/javascript.js
@@ -43,8 +43,8 @@ function enlargePhoto(event) {
             state.selectedPhotoIndex = index;
         }
 
-        // setOverlayPhotoSrc(state.photos[index].url_o);
-        setOverlayPhotoSrc('./styles/pics/kyle3.jpg');
+        setOverlayPhotoSrc(state.photos[index].url_o);
+        //setOverlayPhotoSrc('./styles/pics/kyle3.jpg');
 
         $('body').find($('#overlay-photo')).fadeIn(400);
     }
@@ -52,7 +52,7 @@ function enlargePhoto(event) {
 
 // DOCS for the meat of this: http://www.developerdrive.com/2013/05/creating-a-jquery-gallery-for-flickr/
 (function( $ ) {
-    $.fn.flickr = function(options) {
+    $.fn.loadFlickrPhotos = function(options) {
         var url = 'https://api.flickr.com/services/rest/?jsoncallback=?';
 
         var settings = $.extend( {
@@ -65,13 +65,17 @@ function enlargePhoto(event) {
         return this.each(function() {
             var gallery = $(this);
             gallery.addClass('flickr-gallery');
-            gallery.append('<div class="viewport"></div><div class="browser"><ul></ul></div><div class="clear"></div>');
+            gallery.append(
+                '<div class="browser">' +
+                    '<ul class=' + settings.classes + '></ul>' +
+                '</div>'
+            );
 
             $.getJSON(url, {
                 method: 'flickr.photosets.getPhotos', // DOCS https://www.flickr.com/services/api/flickr.photosets.getPhotos.html
                 api_key: settings.api_key,
                 user_id: settings.user_id,
-                photoset_id: '72157704053325964',
+                photoset_id: settings.photoset_id,
                 format: 'json',
                 extras: 'url_q,url_m,url_z, url_o, date_taken,tags' // DOCS photo size options https://www.flickr.com/services/api/misc.urls.html
             }).success(function(response) {
@@ -120,5 +124,18 @@ $(document).keyup(function(e) {
 });
 
 $(document).on('ready', function(){
-    $('div#gallery').flickr({ photoset_id: '72157626766436507'});
+    if (window.location.pathname.includes('index')){
+        // load index featured photos album
+        $('div#gallery').loadFlickrPhotos({ 
+            photoset_id: '72157704053325964',
+            per_page: 9,
+            classes: 'rectangles'
+        });
+    } else if(window.location.pathname.includes('portfolio')){
+        // load portfolio photos album
+        $('div#gallery').loadFlickrPhotos({ 
+            photoset_id: '72157708286336705',
+            classes: 'squares'
+        });
+    }
 });

--- a/portfolio.html
+++ b/portfolio.html
@@ -44,7 +44,7 @@
             </div>
         </section>
         <footer class="no-shrink">
-            <p><span class="copyright">©</span> Kyle Donahue 2018. All rights reserved.</p>
+            <p><span class="copyright">©</span> Kyle Donahue 2019. All rights reserved.</p>
         </footer>
     </body>
 </html>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -37,33 +37,33 @@ body {
     margin: 0;
 }
 
-#gallery ul.rectangles {
+#gallery ul.uniform {
     display: flex;
     flex-wrap: wrap;
 }
 
 /* DOCS https://css-tricks.com/seamless-responsive-photo-grid/ */
-#gallery ul.squares {
+#gallery ul.ragged {
     column-count: 4;
     line-height: 0;
-    column-gap: .75rem;
+    column-gap: .5rem;
 }
 
 #gallery ul li {
     text-align: center;
 }
 
-#gallery ul.rectangles li {
+#gallery ul.uniform li {
     width: 33.33%;
     padding-bottom: 1rem;
 }
 
-#gallery ul.squares img {
+#gallery ul.ragged img {
     width: 100%;
-    padding: 0 0 .75rem 0;
+    padding: 0 0 .5rem 0;
 }
 
-#gallery ul.rectangles img {
+#gallery ul.uniform img {
     width: calc(100% - 1rem);
     padding: 0 .5rem;
 }
@@ -91,14 +91,14 @@ footer .copyright {
     .content {
         width: 98%;
     }
-    #gallery ul.rectangles li {
+    #gallery ul.uniform li {
         width: 100%;
         padding-bottom: .5rem;
     }
-    #gallery ul.squares {
+    #gallery ul.ragged {
         column-gap: .25rem;
     }
-    #gallery ul.squares img {
-        padding: 0 0 .25rem 0;
+    #gallery ul.ragged img {
+        padding-bottom: .25rem;
     }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -34,18 +34,36 @@ body {
 #gallery ul {
     list-style-type: none;
     padding: 0;
-    display: flex;
-    flex-wrap: wrap;
     margin: 0;
 }
 
+#gallery ul.rectangles {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+/* DOCS https://css-tricks.com/seamless-responsive-photo-grid/ */
+#gallery ul.squares {
+    column-count: 4;
+    line-height: 0;
+    column-gap: .75rem;
+}
+
 #gallery ul li {
-    width: 33.33%;
     text-align: center;
+}
+
+#gallery ul.rectangles li {
+    width: 33.33%;
     padding-bottom: 1rem;
 }
 
-#gallery img {
+#gallery ul.squares img {
+    width: 100%;
+    padding: 0 0 .75rem 0;
+}
+
+#gallery ul.rectangles img {
     width: calc(100% - 1rem);
     padding: 0 .5rem;
 }
@@ -73,7 +91,7 @@ footer .copyright {
     .content {
         width: 98%;
     }
-    #gallery ul li {
+    #gallery ul.rectangles li {
         width: 100%;
         padding-bottom: .5rem;
     }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -95,4 +95,10 @@ footer .copyright {
         width: 100%;
         padding-bottom: .5rem;
     }
+    #gallery ul.squares {
+        column-gap: .25rem;
+    }
+    #gallery ul.squares img {
+        padding: 0 0 .25rem 0;
+    }
 }


### PR DESCRIPTION
Displaying the portfolio images in columns allows them to keep their aspect ratios and still look good in a grid. I used this as a reference: https://css-tricks.com/seamless-responsive-photo-grid/

Changes:
* change copyright to 2019
* change document onready to differentiate between index and portfolio albums and only load them on their respective pages
* switch portfolio list to display photos in a column layout so photos can keep their aspect ratios. the bottom is lumpy, though, and left and right arrows actually navigate you up and down in the gallery now that it's in columns
* get rid of some unnecessary divs in the gallery, format them to be easier to read in the code
* rename 'flickr' function to be 'loadFlickrPhotos' for clarity
* temporarily disable easter egg, left it commented

![Screenshot (1)](https://user-images.githubusercontent.com/5579873/61999742-aa94b980-b095-11e9-9a88-9a4bcd283030.png)
![Screenshot (2)](https://user-images.githubusercontent.com/5579873/61999743-ae284080-b095-11e9-9158-825105b307fc.png)
