### PR TITLE
In mobile view, make Portfolio display images in one column

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -96,7 +96,7 @@ footer .copyright {
         padding-bottom: .5rem;
     }
     #gallery ul.ragged {
-        column-gap: .25rem;
+        column-count: 1;
     }
     #gallery ul.ragged img {
         padding-bottom: .25rem;


### PR DESCRIPTION
With this change, when the Portfolio page is less than 800px wide, we switch to displaying the images in one column rather than four. 

Before: 
![before](https://user-images.githubusercontent.com/5579873/62178250-5fd5a480-b316-11e9-9acc-1d5dc2b4f0f2.png)

After:
![after](https://user-images.githubusercontent.com/5579873/62178255-6532ef00-b316-11e9-9ea3-02e83559f544.png)
